### PR TITLE
Enable cache of ~/.npm on GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,6 +17,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Restore cache if available
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-${{ matrix.node-version }}-
     - name: npm install, build, and test
       run: |
         npm ci


### PR DESCRIPTION
手元で試した感じではあまり効果がない気はしましたが，一応これで~/.npmのキャッシュが効くので少し高速化するはずです．

UbuntuまたはmacOSではこの設定で問題ありませんが，WindowsでもCIしたい場合には少し書き換える必要があります．

参考：https://github.com/actions/cache/blob/master/examples.md