### PR TITLE
Fix/verb

### DIFF
--- a/src/latex-to-ast/command/verbatim.ts
+++ b/src/latex-to-ast/command/verbatim.ts
@@ -24,7 +24,7 @@ export interface CommandNode {
 
 export const Verbatim = (r: Rules) => {
   return Parsimmon.seqObj<CommandNode>(
-    ["name", Parsimmon.regexp(/\\(verb\*?)/, 1)],
+    ["name", Parsimmon.regexp(/\\(verb)\*?/, 1)],
     ["arguments", Parsimmon.regexp(/([^a-z^A-Z\s\\\*])(.*?)\1/, 2).map(_ => [_])]
   ).node("command");
 };

--- a/src/latex-to-ast/command/verbatim.ts
+++ b/src/latex-to-ast/command/verbatim.ts
@@ -24,7 +24,7 @@ export interface CommandNode {
 
 export const Verbatim = (r: Rules) => {
   return Parsimmon.seqObj<CommandNode>(
-    ["name", Parsimmon.regexp(/\\(verb*?)/, 1)],
-    ["arguments", Parsimmon.regexp(/\|.*?\|/, 1).map(_ => [_])]
+    ["name", Parsimmon.regexp(/\\(verb\*?)/, 1)],
+    ["arguments", Parsimmon.regexp(/([^a-z^A-Z\s\\\*])(.*?)\1/, 2).map(_ => [_])]
   ).node("command");
 };

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -28,6 +28,18 @@ describe("Parsimmon AST", () => {
       expect(LaTeX.Program.tryParse(code).value.length).toBe(1);
     }
   });
+  test("verb", async () => {
+    const codes = [
+      `\\verb|abc|`,
+      `\\verb%|$|%`,
+      `\\verb$%^&$`,
+    ];
+    for(const code of codes) {
+      const ast = LaTeX.Program.tryParse(code);
+      expect(ast.value[0].value.name).toBe("verb");
+      expect(ast.value[0].value.arguments[0].length).toBe(3);
+    }
+  });
   test("non-null opt", async () => {
     const code = `
         \\documentclass{article}

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -33,6 +33,9 @@ describe("Parsimmon AST", () => {
       `\\verb|abc|`,
       `\\verb%|$|%`,
       `\\verb$%^&$`,
+      `\\verb*|abc|`,
+      `\\verb*%|$|%`,
+      `\\verb*$%^&$`,
     ];
     for(const code of codes) {
       const ast = LaTeX.Program.tryParse(code);


### PR DESCRIPTION
fix #20 

- `\verb`を正しくパース出来るように修正
  - 空白，英字，アスタリスク，バックスラッシュを除く文字で囲まれた範囲を認識

どの記号が有効なのか調べていないためかなり雑な実装になっています．すいません．