### PR TITLE
Implement verbatim environment

### DIFF
--- a/src/latex-to-ast/environment/index.ts
+++ b/src/latex-to-ast/environment/index.ts
@@ -20,4 +20,4 @@ export { Figure } from "./figure";
 export { InlineMath } from "./inlinemath";
 export { Document } from "./document";
 export { List } from "./list";
-export { Verbatim as VerbatimEnv } from "./verbatim";
+export { VerbatimEnv } from "./verbatim";

--- a/src/latex-to-ast/environment/verbatim.ts
+++ b/src/latex-to-ast/environment/verbatim.ts
@@ -14,10 +14,20 @@
  * You should have received a copy of the GNU General Public License
  * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
-export { DisplayMath } from "./displaymath";
-export { Environment } from "./common";
-export { Figure } from "./figure";
-export { InlineMath } from "./inlinemath";
-export { Document } from "./document";
-export { List } from "./list";
-export { Verbatim as VerbatimEnv } from "./verbatim";
+
+import Parsimmon from "parsimmon";
+import { Rules } from "../rules";
+import { BeginEnvironment, EndEnvironment, EnvironmentNode } from "./common";
+
+export const Verbatim = (r: Rules) => {
+  const context = { name: "", parents: [] };
+  return Parsimmon.seqObj<EnvironmentNode>(
+    ["name", BeginEnvironment("verbatim\\*?", context)],
+    ["arguments", Parsimmon.alt(r.Option, r.Argument).many()],
+    [
+      "body",
+      Parsimmon.regexp(/(?:(?!\\end\{verbatim\*?})[\s\S])*/).node("text")
+    ],
+    EndEnvironment(context)
+  ).node("environment");
+};

--- a/src/latex-to-ast/environment/verbatim.ts
+++ b/src/latex-to-ast/environment/verbatim.ts
@@ -19,7 +19,7 @@ import Parsimmon from "parsimmon";
 import { Rules } from "../rules";
 import { BeginEnvironment, EndEnvironment, EnvironmentNode } from "./common";
 
-export const Verbatim = (r: Rules) => {
+export const VerbatimEnv = (r: Rules) => {
   const context = { name: "", parents: [] };
   return Parsimmon.seqObj<EnvironmentNode>(
     ["name", BeginEnvironment("verbatim\\*?", context)],

--- a/src/latex-to-ast/index.ts
+++ b/src/latex-to-ast/index.ts
@@ -174,6 +174,20 @@ export const parse = (text: string): any => {
                 children: node.value.arguments.concat(node.value.body)
               });
               break;
+            case "verbatim":
+              this.update({
+                ...tmp,
+                type: ASTNodeTypes.CodeBlock,
+                value: node.value.arguments.concat(node.value.body)
+              });
+              break;
+            case "verbatim*":
+              this.update({
+                ...tmp,
+                type: ASTNodeTypes.CodeBlock,
+                value: node.value.arguments.concat(node.value.body)
+              });
+              break;
             default:
               this.update({
                 ...tmp,

--- a/src/latex-to-ast/latex.ts
+++ b/src/latex-to-ast/latex.ts
@@ -22,7 +22,8 @@ import {
   Figure,
   InlineMath,
   Document,
-  List
+  List,
+  VerbatimEnv
 } from "./environment";
 import { Command, Verbatim } from "./command";
 import { Text } from "./text";
@@ -38,6 +39,7 @@ export const LaTeX = Parsimmon.createLanguage({
   DisplayMath,
   Figure,
   InlineMath,
+  VerbatimEnv,
   Command,
   Verbatim,
   Argument,
@@ -50,6 +52,7 @@ export const LaTeX = Parsimmon.createLanguage({
       r.DisplayMath,
       r.InlineMath,
       r.List,
+      r.VerbatimEnv,
       r.Document,
       r.Environment
     );

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -3,6 +3,7 @@ import "jest";
 import { parse } from "../src/latex-to-ast";
 import { LaTeX } from "../src/latex-to-ast/latex";
 import { TextlintKernel } from "@textlint/kernel";
+import { debuglog } from "util";
 
 describe("Parsimmon AST", () => {
   test("non-null", async () => {
@@ -133,6 +134,18 @@ describe("Parsimmon AST", () => {
     const ast = LaTeX.Program.tryParse(code);
     expect(ast.value[0].value.name).toBe("figure");
     expect(ast.value[2].value.name).toBe("figure*");
+  });
+  test("verbatim environment", async () => {
+    const code = `\\begin{verbatim}
+        %$#*:;@+=
+        \\end{verbatim}
+
+        \\begin{verbatim*}
+        %$#*:;@+=
+        \\end{verbatim*}`;
+    const ast = LaTeX.Program.tryParse(code);
+    expect(ast.value[0].value.name).toBe("verbatim");
+    expect(ast.value[3].value.name).toBe("verbatim*");
   });
   test("nested environments", async () => {
     const code = `\\begin{figure}

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -3,7 +3,6 @@ import "jest";
 import { parse } from "../src/latex-to-ast";
 import { LaTeX } from "../src/latex-to-ast/latex";
 import { TextlintKernel } from "@textlint/kernel";
-import { debuglog } from "util";
 
 describe("Parsimmon AST", () => {
   test("non-null", async () => {
@@ -139,13 +138,13 @@ describe("Parsimmon AST", () => {
     const code = `\\begin{verbatim}
         %$#*:;@+=
         \\end{verbatim}
-
         \\begin{verbatim*}
         %$#*:;@+=
         \\end{verbatim*}`;
     const ast = LaTeX.Program.tryParse(code);
     expect(ast.value[0].value.name).toBe("verbatim");
-    expect(ast.value[3].value.name).toBe("verbatim*");
+    // ast.value[1] is a text node ("\n        ")
+    expect(ast.value[2].value.name).toBe("verbatim*");
   });
   test("nested environments", async () => {
     const code = `\\begin{figure}


### PR DESCRIPTION
fix #23 

Parsimmonを触るのは初めてなので，もっと良い書き方があればご指摘頂けますと幸いです．

verbatimは文字列をそのまま解釈してレンダリングする記法であるため，内部の文字列をコメントや他の記法として解釈されないよう，`\end{verbatim}`までの否定先読みの正規表現を使ってそのままパースしています．また，CodeBlockとしてマッピングしています．
また，`src/latex-to-ast/command/verbatim.ts`内の`Verbatim`と重複しないよう，`VirbatimEnv`として定義しました．既存の方を`Verb`として置き換えることも考えましたが後方互換性を考えEnvというサフィックスを付けました．