### PR TITLE
Fix AST errors from verbatiom environment

### DIFF
--- a/src/latex-to-ast/index.ts
+++ b/src/latex-to-ast/index.ts
@@ -178,14 +178,14 @@ export const parse = (text: string): any => {
               this.update({
                 ...tmp,
                 type: ASTNodeTypes.CodeBlock,
-                value: node.value.arguments.concat(node.value.body)
+                value: node.value.body.value
               });
               break;
             case "verbatim*":
               this.update({
                 ...tmp,
                 type: ASTNodeTypes.CodeBlock,
-                value: node.value.arguments.concat(node.value.body)
+                value: node.value.body.value
               });
               break;
             default:


### PR DESCRIPTION
fix #26 
`CodeBlock`ノードでは、valueが文字列でなければいけません。
しかし、Parsimmonからの出力ではオブジェクトとなっているので、文字列だけを取り出すようにしました。